### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - '**.py'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ccleberg/crumb/security/code-scanning/1](https://github.com/ccleberg/crumb/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should explicitly define the least privileges required for the workflow to function correctly. Since the workflow involves committing changes to the repository, it requires `contents: write`. Other permissions should be set to `read` or omitted entirely if not needed.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build` job. In this case, adding it at the root level is sufficient and ensures clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
